### PR TITLE
update download link, file path, and encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 #
 
 # download page: https://nknet.ninjal.ac.jp/nuc/templates/nuc.html
-CORPUS_URL = https://nknet.ninjal.ac.jp/nuc/nuc.zip
-ZIP_FILE = nuc.zip
-UNZIP_DIR = nuc
+CORPUS_URL = http://mmsrv.ninjal.ac.jp/nucc/nucc.zip
+ZIP_FILE = nucc.zip
+UNZIP_DIR = nucc
 WGET = wget
 UNZIP = unzip
 PYTHON = python
@@ -25,8 +25,8 @@ $(SEQFILE): $(UNZIP_DIR)
 
 download: $(ZIP_FILE)
 
-nuc.zip:
+nucc.zip:
 	$(WGET) $(CORPUS_URL)
 
-$(UNZIP_DIR): nuc.zip
+$(UNZIP_DIR): nucc.zip
 	$(UNZIP) -x $(ZIP_FILE)

--- a/mksequence.py
+++ b/mksequence.py
@@ -7,12 +7,12 @@ try:
     import codecs
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
     def copen(fname, mode):
-        return codecs.open(fname, mode, "euc_jp")
+        return codecs.open(fname, mode, "utf-8")
 except:
     def copen(fname, mode):
-        return open(fname, mode, encoding='euc-jp')
+        return open(fname, mode, encoding='utf-8')
 
-nuc_dir = "nuc"
+nuc_dir = "nucc"
 
 def make_sequence_from_file(fname):
     fname = os.path.join(nuc_dir, fname)


### PR DESCRIPTION
Updated below:
- Corpus download link is changed to `http://mmsrv.ninjal.ac.jp/nucc/nucc.zip`
- File name is changed to `nucc.zip`
- Encoding is changed to `utf-8`